### PR TITLE
Repositories should not be named "kepler" and "keplerupdate"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,12 @@
       <layout>p2</layout>
     </repository>
     <repository>
-      <id>kepler</id>
+      <id>eclipse</id>
       <url>http://download.eclipse.org/releases/luna</url>
       <layout>p2</layout>
     </repository>
     <repository>
-      <id>keplerupdate</id>
+      <id>eclipse-updates</id>
       <url>http://download.eclipse.org/eclipse/updates/4.4</url>
       <layout>p2</layout>
     </repository>


### PR DESCRIPTION
Please use common names like "eclipse" and "eclipse-updates" (same as in cs-studio/core) for the repository names.