### PR TITLE
moving to 4.2, eclipse 4.5 mars, and removing 32bit archs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <!-- VERSIONS -->
     <tycho.version>0.22.0</tycho.version>
     <tycho-extras.version>0.22.0</tycho-extras.version>
-    <cs-studio-central.url>http://download.controlsystemstudio.org/thirdparty/4.1</cs-studio-central.url>
+    <cs-studio-central.url>http://download.controlsystemstudio.org/thirdparty/4.2</cs-studio-central.url>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree>
     <baselineMode>fail</baselineMode>
@@ -56,17 +56,17 @@
   <repositories>
     <repository>
       <id>csstudio-maven-osgi-bundles</id>
-      <url>http://download.controlsystemstudio.org/maven-osgi-bundles/4.1</url>
+      <url>http://download.controlsystemstudio.org/maven-osgi-bundles/4.2</url>
       <layout>p2</layout>
     </repository>
     <repository>
       <id>eclipse</id>
-      <url>http://download.eclipse.org/releases/luna</url>
+      <url>http://download.eclipse.org/releases/mars</url>
       <layout>p2</layout>
     </repository>
     <repository>
       <id>eclipse-updates</id>
-      <url>http://download.eclipse.org/eclipse/updates/4.4</url>
+      <url>http://download.eclipse.org/eclipse/updates/4.5</url>
       <layout>p2</layout>
     </repository>
   </repositories>
@@ -207,17 +207,7 @@
               <environment>
                 <os>linux</os>
                 <ws>gtk</ws>
-                <arch>x86</arch>
-              </environment>
-              <environment>
-                <os>linux</os>
-                <ws>gtk</ws>
                 <arch>x86_64</arch>
-              </environment>
-              <environment>
-                <os>win32</os>
-                <ws>win32</ws>
-                <arch>x86</arch>
               </environment>
               <environment>
                 <os>win32</os>
@@ -227,7 +217,7 @@
               <environment>
                 <os>macosx</os>
                 <ws>cocoa</ws>
-                <arch>x86</arch>
+                <arch>x86_64</arch>
               </environment>
           </environments>
         </configuration>


### PR DESCRIPTION
Now that cs-studio/master uses mars, cs-studio-thirdparty/master should match