### PR TITLE
Update pom to build against Eclipse Oxygen.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,12 @@
   <repositories>
     <repository>
       <id>eclipse</id>
-      <url>http://download.eclipse.org/releases/neon/</url>
+      <url>http://download.eclipse.org/releases/oxygen/</url>
       <layout>p2</layout>
     </repository>
     <repository>
       <id>eclipse-updates</id>
-      <url>http://download.eclipse.org/eclipse/updates/4.6</url>
+      <url>http://download.eclipse.org/eclipse/updates/4.7</url>
       <layout>p2</layout>
     </repository>
   </repositories>


### PR DESCRIPTION
I simply updated the p2 repositories in all the repos to Oxygen and everything seemed to build fine.

I expect @berryma4 will be able to spot if I've missed something.