### PR TITLE
Fix class not found error by using request wrapper to add attachments

### DIFF
--- a/plugins/edu.msu.nscl.olog.api/src/edu/msu/nscl/olog/api/OlogClientImpl.java
+++ b/plugins/edu.msu.nscl.olog.api/src/edu/msu/nscl/olog/api/OlogClientImpl.java
@@ -823,14 +823,19 @@ public class OlogClientImpl implements OlogClient {
 
 	@Override
 	public Attachment add(File local, Long logId) throws OlogException {
-		FormDataMultiPart form = new FormDataMultiPart();
-		form.bodyPart(new FileDataBodyPart("file", local));
-		XmlAttachment xmlAttachment = service.path("attachments")
-				.path(logId.toString()).type(MediaType.MULTIPART_FORM_DATA)
-				.accept(MediaType.APPLICATION_XML)
-				.post(XmlAttachment.class, form);
+		return wrappedSubmit(new Callable<Attachment>() {
+			@Override
+			public Attachment call() throws Exception {
+				FormDataMultiPart form = new FormDataMultiPart();
+				form.bodyPart(new FileDataBodyPart("file", local));
+				XmlAttachment xmlAttachment = service.path("attachments")
+						.path(logId.toString()).type(MediaType.MULTIPART_FORM_DATA)
+						.accept(MediaType.APPLICATION_XML)
+						.post(XmlAttachment.class, form);
 
-		return new Attachment(xmlAttachment);
+				return new Attachment(xmlAttachment);
+			}
+		});
 	}
 
 	@Override


### PR DESCRIPTION
For some reason the add() method is one of the few service requests that did not use the wrappedSubmit() methods. This fixes the ClassNotFound exception.

See CS Studio issue [2638](https://github.com/ControlSystemStudio/cs-studio/issues/2638) for details.